### PR TITLE
(Invites) Fix trying to clear reactions of a message that no longer exists

### DIFF
--- a/invites/invites.py
+++ b/invites/invites.py
@@ -309,7 +309,8 @@ class Invites(commands.Cog):
                     i -= 1
                 elif str(reaction.emoji) == "❌":
                     await message.delete()
-                    break
+                    # return instead of breaking so we don't try to clear reactions on a message that no longer exists
+                    return
 
                 i = i % len(pages)
 


### PR DESCRIPTION
Currently, if you use `[p]invites stats` and use the ❌ reaction to close the menu (delete the message), the command will try and clear the message's reactions after it has already been deleted. This pr fixes that behavior by returning early instead of breaking early.